### PR TITLE
Removed exception being thrown when projection param is not found

### DIFF
--- a/DotSpatial.Projections/AuthorityCodes/AuthorityCodeHandler.cs
+++ b/DotSpatial.Projections/AuthorityCodes/AuthorityCodeHandler.cs
@@ -140,6 +140,10 @@ namespace DotSpatial.Projections.AuthorityCodes
             try
             {
                 pi = ProjectionInfo.FromProj4String(proj4String);
+
+                // Removed exception being thrown when projection is not found
+                if (pi.Transform == null)
+                    return;
             }
             catch (ProjectionException)
             {
@@ -147,7 +151,7 @@ namespace DotSpatial.Projections.AuthorityCodes
                 if (proj4String.Contains("+proj=geocent")) return;
                 throw;
             }
-            
+
             pi.Authority = authorityCode.Substring(0, pos);
             pi.AuthorityCode = int.Parse(authorityCode.Substring(pos + 1), CultureInfo.InvariantCulture);
             pi.Name = string.IsNullOrEmpty(name) ? authorityCode : name;

--- a/DotSpatial.Projections/Transforms/TransformManager.cs
+++ b/DotSpatial.Projections/Transforms/TransformManager.cs
@@ -15,6 +15,7 @@
 // ********************************************************************************************************
 
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace DotSpatial.Projections.Transforms
 {
@@ -126,7 +127,9 @@ namespace DotSpatial.Projections.Transforms
                     if (prj4Name == name) return transform.Copy();
                 }
             }
-            throw new ProjectionException(37);
+            Trace.WriteLine($"Unrecognized '{name}'");
+            return null;
+            //throw new ProjectionException(37);
         }
 
         /// <summary>


### PR DESCRIPTION
Hi @ststeiger. I have removed exception thrown when a param was not found.
This was causing a veeeeeeeery slow debugging startup on VisualStudio for Mac.

BTW thanks for this cool port to netstandard ;)